### PR TITLE
Slett tp-forhold vha REST

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/elsam/minibuss/nav_cons_elsam_tptilb_registreretpforholdV0_1/Mapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/elsam/minibuss/nav_cons_elsam_tptilb_registreretpforholdV0_1/Mapper.kt
@@ -1,43 +1,8 @@
 package no.nav.pensjon.elsam.minibuss.nav_cons_elsam_tptilb_registreretpforholdV0_1
 
 import nav_cons_elsam_tptilb_registreretpforhold.no.nav.asbo.OpprettTPForholdRequestInt
-import nav_cons_elsam_tptilb_registreretpforhold.no.nav.asbo.SlettTPForholdFinnTjenestepensjonsforholdRequestInt
-import nav_cons_elsam_tptilb_registreretpforhold.no.nav.asbo.SlettTPForholdTjenestepensjonRequestInt
-import nav_lib_cons_sto_sam.no.nav.lib.sto.sam.asbo.tjenestepensjon.ASBOStoFinnTjenestepensjonsforholdRequest
 import nav_lib_cons_sto_sam.no.nav.lib.sto.sam.asbo.tjenestepensjon.ASBOStoTjenestepensjon
 import nav_lib_cons_sto_sam.no.nav.lib.sto.sam.asbo.tjenestepensjon.ASBOStoTjenestepensjonforhold
-import nav_lib_frg.no.nav.lib.frg.fault.FaultElementetErUgyldig
-import nav_lib_frg.no.nav.lib.frg.fault.FaultElementetFinnesIkke
-import nav_lib_frg.no.nav.lib.frg.fault.FaultTomDatoForanFomDato
-import nav_lib_frg.no.nav.lib.frg.gbo.GBOTjenestepensjonForhold
-import no.nav.elsam.registreretpforhold.v0_1.FaultGenerisk
-import no.nav.elsam.registreretpforhold.v0_1.FaultTjenestepensjonForholdIkkeFunnet
-import javax.xml.datatype.DatatypeFactory
-
-// FaultElementetErUgyldigTOFaultTjenestepensjonForholdIkkeFunnet.map
-fun FaultElementetErUgyldig.toFaultTjenestepensjonForholdIkkeFunnet() =
-    FaultTjenestepensjonForholdIkkeFunnet().also {
-        it.errorMessage = errorMessage // move (executionOrder=1)
-        it.errorSource = errorSource // move (executionOrder=2)
-        it.rootCause = rootCause // move (executionOrder=3)
-        it.dateTimeStamp = dateTimeStamp?.let { dts -> DatatypeFactory.newInstance().newXMLGregorianCalendar(dts) } // move (executionOrder=4)
-    }
-
-// FaultElementetFinnesIkkeTOFaultTjenestepensjonForholdIkkeFunnet.map
-fun FaultElementetFinnesIkke.toFaultTjenestepensjonForholdIkkeFunnet() =
-    FaultTjenestepensjonForholdIkkeFunnet().also {
-        it.errorMessage = errorMessage // move (executionOrder=1)
-        it.errorSource = errorSource // move (executionOrder=2)
-        it.rootCause = rootCause // move (executionOrder=3)
-        it.dateTimeStamp = dateTimeStamp?.let { dts -> DatatypeFactory.newInstance().newXMLGregorianCalendar(dts) } // move (executionOrder=4)
-    }
-
-// FaultTomDatoForanFomDatoTOFaultGenerisk.map
-fun FaultTomDatoForanFomDato.toFaultGenerisk() =
-    FaultGenerisk().also {
-        it.errorDescription = errorMessage // move (executionOrder=1)
-        it.errorCode = "InternalError" // set (executionOrder=2)
-    }
 
 // OpprettTPForholdRequestIntTOGBOTjenestepensjon.map
 fun OpprettTPForholdRequestInt.toGBOTjenestepensjon() =
@@ -53,18 +18,4 @@ fun OpprettTPForholdRequestInt.toGBOTjenestepensjonForhold() =
         it.harUtlandPensjon = false // set (executionOrder=2)
         it.samtykkeSimuleringKode = if (extRequest?.samtykke?.value == true) "J" else "N" // custom.output assignment (executionOrder=3)
         it.harSimulering = false // set (executionOrder=4)
-    }
-
-// SlettTPForholdRequestIntTOGBOFinnTjenestepensjonsforholdRequest.map
-fun SlettTPForholdFinnTjenestepensjonsforholdRequestInt.toGBOFinnTjenestepensjonsforholdRequest() =
-    ASBOStoFinnTjenestepensjonsforholdRequest().also {
-        it.tssEksternId = eksternTSSId // move (executionOrder=1)
-        it.fnr = extRequest?.fnr // move (executionOrder=2)
-        it.hentSamhandlerInfo = false // set (executionOrder=3)
-    }
-
-// SlettTPForholdRequestIntTOGBOTjenestepensjonForhold.map
-fun SlettTPForholdTjenestepensjonRequestInt.toGBOTjenestepensjonForhold() =
-    GBOTjenestepensjonForhold().also {
-        it.forholdId = forholdId // move (executionOrder=1)
     }

--- a/src/main/kotlin/no/nav/pensjon/elsam/minibuss/nav_cons_elsam_tptilb_registreretpforholdV0_1/RegistrereTPForholdIntTOTjenestepensjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/elsam/minibuss/nav_cons_elsam_tptilb_registreretpforholdV0_1/RegistrereTPForholdIntTOTjenestepensjon.kt
@@ -1,21 +1,15 @@
 package no.nav.pensjon.elsam.minibuss.nav_cons_elsam_tptilb_registreretpforholdV0_1
 
 import nav_cons_elsam_tptilb_registreretpforhold.no.nav.asbo.OpprettTPForholdRequestInt
-import nav_cons_elsam_tptilb_registreretpforhold.no.nav.asbo.SlettTPForholdFinnTjenestepensjonsforholdRequestInt
-import nav_cons_elsam_tptilb_registreretpforhold.no.nav.asbo.SlettTPForholdTjenestepensjonRequestInt
 import nav_cons_elsam_tptilb_registreretpforhold.no.nav.inf.*
 import nav_cons_sto_sam_tjenestepensjon.no.nav.inf.OpprettTjenestepensjonsforholdFaultStoElementetErDuplikatMsg
 import nav_cons_sto_sam_tjenestepensjon.no.nav.inf.SAMTjenestepensjon
-import nav_lib_cons_sto_sam.no.nav.lib.sto.sam.asbo.tjenestepensjon.ASBOStoTjenestepensjon
 import nav_lib_frg.no.nav.lib.frg.fault.FaultElementetErDuplikat
-import nav_lib_frg.no.nav.lib.frg.inf.tjenestepensjon.*
 import org.springframework.stereotype.Component
 
 @Component
 class RegistrereTPForholdIntTOTjenestepensjon(
-    private val finnTjenestepensjonsforhold: SAMTjenestepensjon,
     private val samTjenstepensjon: SAMTjenestepensjon,
-    private val tjenestepensjon: Tjenestepensjon,
 ) {
     // RegistrereTPForholdIntTOTjenestepensjon
     fun opprettTPForholdInt(opprettTPForholdRequestInt: OpprettTPForholdRequestInt) {
@@ -31,26 +25,6 @@ class RegistrereTPForholdIntTOTjenestepensjon(
                     dateTimeStamp = it.dateTimeStamp.toString()
                 }
             })
-        }
-    }
-
-    // RegistrereTPForholdIntTOFinnTjenestepensjonsforhold
-    fun slettTPForholdFinnTjenestepensjonsforholdInt(slettTPForholdRequestInt: SlettTPForholdFinnTjenestepensjonsforholdRequestInt): ASBOStoTjenestepensjon {
-        try {
-            return finnTjenestepensjonsforhold.finnTjenestepensjonsforhold(slettTPForholdRequestInt.toGBOFinnTjenestepensjonsforholdRequest())
-        } catch (e: HentTjenestepensjonInfoFaultElementetFinnesIkkeMsg) {
-            throw SlettTPForholdFinnTjenestepensjonsforholdIntFaultTjenestepensjonForholdIkkeFunnetIntMsg(e.message, e.faultInfo?.toFaultTjenestepensjonForholdIkkeFunnet())
-        } catch (e: HentTjenestepensjonInfoFaultTomDatoForanFomDatoMsg) {
-            throw SlettTPForholdFinnTjenestepensjonsforholdIntFaultGeneriskMsg(e.message, e.faultInfo?.toFaultGenerisk())
-        }
-    }
-
-    // RegistrereTPForholdIntTOTjenestepensjon
-    fun slettTPForholdTjenestepensjonInt(slettTPForholdRequestInt: SlettTPForholdTjenestepensjonRequestInt) {
-        try {
-            tjenestepensjon.slettTjenestepensjonsforhold(slettTPForholdRequestInt.toGBOTjenestepensjonForhold())
-        } catch (e: SlettTjenestepensjonsforholdFaultElementetErUgyldigMsg) {
-            throw SlettTPForholdTjenestepensjonIntFaultTjenestepensjonForholdIkkeFunnetIntMsg(e.message, e.faultInfo?.toFaultTjenestepensjonForholdIkkeFunnet())
         }
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/elsam/minibuss/nav_cons_elsam_tptilb_registreretpforholdV0_1/RegistrereTPForholdWSEndpointImpl.kt
+++ b/src/main/kotlin/no/nav/pensjon/elsam/minibuss/nav_cons_elsam_tptilb_registreretpforholdV0_1/RegistrereTPForholdWSEndpointImpl.kt
@@ -92,18 +92,6 @@ class RegistrereTPForholdWSEndpointImpl(
     override fun slettTPForhold(
         @WebParam(name = "slettTPForholdReq", targetNamespace = "") slettTPForholdReq: SlettTPForholdReq
     ) {
-        if (true) {
-            return busRegistrereTPForhold.slettTPForhold(slettTPForholdReq)
-        }
-
-        try {
-            navConsElsamTptilbRegisrereTpForhold.slettTPForhold(slettTPForholdReq)
-        } catch (e: SlettTPForholdFinnTjenestepensjonsforholdIntFaultTjenestepensjonForholdIkkeFunnetIntMsg) {
-            throw SlettTPForholdFaultTjenestepensjonForholdIkkeFunnetMsg(e.message, e.faultInfo)
-        } catch (e: SlettTPForholdFinnTjenestepensjonsforholdIntFaultGeneriskMsg) {
-            throw SlettTPForholdFaultGeneriskMsg(e.message, e.faultInfo)
-        } catch (e: SlettTPForholdTjenestepensjonIntFaultTjenestepensjonForholdIkkeFunnetIntMsg) {
-            throw SlettTPForholdFaultTjenestepensjonForholdIkkeFunnetMsg(e.message, e.faultInfo)
-        }
+        navConsElsamTptilbRegisrereTpForhold.slettTPForhold(slettTPForholdReq)
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/elsam/minibuss/tjenestepensjon/TjenestepensjonService.kt
+++ b/src/main/kotlin/no/nav/pensjon/elsam/minibuss/tjenestepensjon/TjenestepensjonService.kt
@@ -55,6 +55,14 @@ class TjenestepensjonService(
         return tjenestepensjon.forhold.isNotEmpty()
     }
 
+    fun slettTjenestepensjonsforhold(fnr: String, tpNr: String) {
+        tpRestClient.delete()
+            .uri("/api/samhandler/tjenestepensjon/forhold/{tpNr}", mapOf("tpNr" to tpNr))
+            .header("fnr", fnr)
+            .retrieve()
+            .body<String>()
+    }
+
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class OrdningDto(
         val navn: String,


### PR DESCRIPTION
Har verifisert at man får samme feilmelding hvis man prøver å slette forhold som ikke finnes, og hvis man prøver å slette et forhold med ytelse.

Ved ugyldig fnr får man ikke lenger `PidValidationException`, men følgende feilmelding (samme som allerede blir brukt for `finnTjenestepensjonsforhold`): 
```Error Id: 0, Error Message: Cannot process the element bacause the ID = 30515913748 do not refer to a valid element.```

Jeg har forsåvidt også merket at eksisterende kode som konverterer til XMLGregorianCalendar får litt annet format en respons fra bussen. Jeg er usikker på om det burde følges opp. `2024-10-04T12:44:48.926+02:00` vs `2024-10-04T10:44:48.926Z`