### PR TITLE
Opprett refusjonskrav med REST

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/elsam/minibuss/nav_cons_elsam_tptilb_tpsamordningregistrering/TPSamordningRegistreringWSEndpointImpl.kt
+++ b/src/main/kotlin/no/nav/pensjon/elsam/minibuss/nav_cons_elsam_tptilb_tpsamordningregistrering/TPSamordningRegistreringWSEndpointImpl.kt
@@ -103,6 +103,10 @@ class TPSamordningRegistreringWSEndpointImpl(
         ) opprettRefusjonskravReq: OpprettRefusjonskravReq
     ) {
         if (true) {
+            return navConsElsamTplibTpSamordningRegistrering.opprettRefusjonskravRest(opprettRefusjonskravReq)
+        }
+
+        if (true) {
             return busTPSamordningRegistrering.opprettRefusjonskrav(opprettRefusjonskravReq)
         }
 

--- a/src/main/kotlin/no/nav/pensjon/elsam/minibuss/nav_cons_elsam_tptilb_tpsamordningregistrering/TPSamordningRegistreringWSEndpointImpl.kt
+++ b/src/main/kotlin/no/nav/pensjon/elsam/minibuss/nav_cons_elsam_tptilb_tpsamordningregistrering/TPSamordningRegistreringWSEndpointImpl.kt
@@ -1,5 +1,6 @@
 package no.nav.pensjon.elsam.minibuss.nav_cons_elsam_tptilb_tpsamordningregistrering
 
+import io.getunleash.DefaultUnleash
 import jakarta.jws.WebMethod
 import jakarta.jws.WebParam
 import jakarta.jws.WebResult
@@ -35,6 +36,7 @@ import org.springframework.stereotype.Component
 class TPSamordningRegistreringWSEndpointImpl(
     val navConsElsamTplibTpSamordningRegistrering: NavConsElsamTplibTpSamordningRegistrering,
     val busTPSamordningRegistrering: TPSamordningRegistrering,
+    private val unleash: DefaultUnleash
 ) : TPSamordningRegistrering {
     @WebMethod
     @RequestWrapper(
@@ -102,7 +104,7 @@ class TPSamordningRegistreringWSEndpointImpl(
             targetNamespace = ""
         ) opprettRefusjonskravReq: OpprettRefusjonskravReq
     ) {
-        if (true) {
+        if (unleash.isEnabled("pensjon-elsam-minibuss.opprettRefusjonskrav")) {
             return navConsElsamTplibTpSamordningRegistrering.opprettRefusjonskravRest(opprettRefusjonskravReq)
         }
 

--- a/src/main/kotlin/no/nav/pensjon/elsam/minibuss/sam/SamService.kt
+++ b/src/main/kotlin/no/nav/pensjon/elsam/minibuss/sam/SamService.kt
@@ -1,9 +1,11 @@
 package no.nav.pensjon.elsam.minibuss.sam
 
+import no.nav.elsam.tpsamordningregistrering.v0_5.PeriodisertBelop
 import no.nav.elsam.tpsamordningregistrering.v0_5.SlettTPYtelseReq
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
+import java.util.Date
 
 @Service
 class SamService(
@@ -16,4 +18,40 @@ class SamService(
             .retrieve()
             .body<String>()
     }
+
+    fun opprettRefusjonskrav(pid: String, tpNr: String, samId: Long, refusjonskrav: Boolean, periodisertBelopListe: List<PeriodisertBelop>) =
+        samRestClient.post()
+            .uri("/api/refusjonskrav")
+            .body(Refusjonskrav(pid, tpNr, samId, refusjonskrav, periodisertBelopListe.map { it.toRefusjonstrekk() }))
+            .retrieve()
+            .body<OpprettRefusjonskravResponse>()!!
+
+    private fun PeriodisertBelop.toRefusjonstrekk() =
+        Refusjonstrekk(
+            belop = belop,
+            kravstillersRef = kravstillersReferanse,
+            datoFom = datoFom?.toGregorianCalendar()?.time,
+            datoTom = datoTom?.toGregorianCalendar()?.time,
+        )
+
+    data class Refusjonskrav(
+        val pid: String,
+        val tpNr: String,
+        val samId: Long,
+        val refusjonskrav: Boolean,
+        val periodisertBelopListe: List<Refusjonstrekk>
+    )
+
+    data class Refusjonstrekk(
+        val belop: Double?,
+        val kravstillersRef: String?,
+        val datoFom: Date?,
+        val datoTom: Date?,
+    )
+
+    data class OpprettRefusjonskravResponse(
+        val refusjonskravAlleredeRegistrertEllerUtenforFrist: Boolean,
+        val exception: Exception? = null,
+        val exceptionName: String? = null
+    )
 }


### PR DESCRIPTION
- Det er 21 exceptions som extender `SamFunctionalRecoverableException`. Det er mulig at flere av disse burde håndteres, men jeg har så langt bare lagt inn håndtering av de 3 som har oppstått i prod ila siste 90 dager. 
- Exceptions som ikke er `SamFunctionalRecoverableException` resulterer i en 500-response med tom body. Det burde vurderes om alle exceptions burde håndteres i Sam, men da blir det vanskelig for konsumentene å skille mellom `SamFunctionalRecoverableException` og andre exceptions: https://github.com/navikt/sam/pull/205
- Det burde nok tas en ekstra sjekk på at datoer blir riktig, i tilfelle tidssoner blir håndtert annerledes, og fører til forskjellig dato